### PR TITLE
fix: plugin path and cmd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,4 +22,7 @@ COPY --from=build /src/dynamodb-plugin /go/bin
 
 FROM scratch
 
-COPY --from=build /src/dynamodb-plugin /plugin/jaeger-dynamodb
+COPY --from=build /src/dynamodb-plugin /jaeger-dynamodb
+
+# The /plugin is used by the jaeger-operator https://github.com/jaegertracing/jaeger-operator/pull/1517
+CMD ["cp", "/jaeger-dynamodb", "/plugin/jaeger-dynamodb"]


### PR DESCRIPTION
Align with the "spec" used in https://github.com/pavolloffay/jaeger-clickhouse/commit/cb22c51ce66d7504f333d8a03c6a5c00b73d6a58