### PR TITLE
feat: dedupe service and operation writes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,6 +41,7 @@ require (
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/grpc-ecosystem/grpc-opentracing v0.0.0-20180507213350-8e809c8a8645 // indirect
 	github.com/hashicorp/go-plugin v1.4.3 // indirect
+	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/hashicorp/yamux v0.0.0-20210826001029-26ff87cf9493 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -251,6 +251,8 @@ github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/b
 github.com/hashicorp/go.net v0.0.1/go.mod h1:hjKkEWcCURg++eb33jQU7oqQcI9XDCnUzHA0oac0k90=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
+github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
+github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=

--- a/plugin/dynamospanstore/reader_test.go
+++ b/plugin/dynamospanstore/reader_test.go
@@ -67,7 +67,8 @@ func TestGetServices(t *testing.T) {
 
 	svc := createDynamoDBSvc(assert, ctx)
 	reader := NewReader(logger, svc, spansTable, servicesTable, operationsTable)
-	writer := NewWriter(logger, svc, spansTable, servicesTable, operationsTable)
+	writer, err := NewWriter(logger, svc, spansTable, servicesTable, operationsTable)
+	assert.NoError(err)
 
 	assert.NoError(setup.RecreateTables(ctx, svc, &setup.SetupOptions{
 		SpansTable:      spansTable,
@@ -130,7 +131,8 @@ func TestGetOperations(t *testing.T) {
 
 	svc := createDynamoDBSvc(assert, ctx)
 	reader := NewReader(logger, svc, spansTable, servicesTable, operationsTable)
-	writer := NewWriter(logger, svc, spansTable, servicesTable, operationsTable)
+	writer, err := NewWriter(logger, svc, spansTable, servicesTable, operationsTable)
+	assert.NoError(err)
 
 	assert.NoError(setup.RecreateTables(ctx, svc, &setup.SetupOptions{
 		SpansTable:      spansTable,
@@ -257,7 +259,8 @@ func TestFindTraces(t *testing.T) {
 
 	svc := createDynamoDBSvc(assert, ctx)
 	reader := NewReader(logger, svc, spansTable, servicesTable, operationsTable)
-	writer := NewWriter(logger, svc, spansTable, servicesTable, operationsTable)
+	writer, err := NewWriter(logger, svc, spansTable, servicesTable, operationsTable)
+	assert.NoError(err)
 
 	assert.NoError(setup.RecreateTables(ctx, svc, &setup.SetupOptions{
 		SpansTable:      spansTable,

--- a/plugin/dynamospanstore/writer_test.go
+++ b/plugin/dynamospanstore/writer_test.go
@@ -1,0 +1,93 @@
+package dynamospanstore
+
+import (
+	"context"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/gogo/protobuf/jsonpb"
+	"github.com/hashicorp/go-hclog"
+	"github.com/jaegertracing/jaeger/model"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockPutItemAPI func(ctx context.Context, params *dynamodb.PutItemInput, optFns ...func(*dynamodb.Options)) (*dynamodb.PutItemOutput, error)
+
+func (m mockPutItemAPI) PutItem(ctx context.Context, params *dynamodb.PutItemInput, optFns ...func(*dynamodb.Options)) (*dynamodb.PutItemOutput, error) {
+	return m(ctx, params, optFns...)
+}
+
+func TestWriteSpanDedupe(t *testing.T) {
+	assert := assert.New(t)
+
+	logLevel := os.Getenv("GRPC_STORAGE_PLUGIN_LOG_LEVEL")
+	if logLevel == "" {
+		logLevel = hclog.Warn.String()
+	}
+
+	logger := hclog.New(&hclog.LoggerOptions{
+		Level:      hclog.LevelFromString(logLevel),
+		Name:       loggerName,
+		JSONFormat: true,
+	})
+
+	ctx := context.TODO()
+
+	var (
+		spansTable      = "jaeger.spans"
+		servicesTable   = "jaeger.services"
+		operationsTable = "jaeger.operations"
+	)
+
+	writesPerTable := map[string]int{
+		spansTable:      0,
+		servicesTable:   0,
+		operationsTable: 0,
+	}
+
+	var mu sync.Mutex
+	svc := mockPutItemAPI(func(ctx context.Context, params *dynamodb.PutItemInput, optFns ...func(*dynamodb.Options)) (*dynamodb.PutItemOutput, error) {
+		mu.Lock()
+		writesPerTable[*params.TableName] += 1
+		mu.Unlock()
+
+		return nil, nil
+	})
+
+	writer, err := NewWriter(logger, svc, spansTable, servicesTable, operationsTable)
+	assert.NoError(err)
+
+	var span model.Span
+	assert.NoError(jsonpb.Unmarshal(strings.NewReader(`{
+		"traceId": "AAAAAAAAAAAAAAAAAAAAEQ==",
+		"spanId": "AAAAAAAAAAM=",
+		"operationName": "example-operation-1",
+		"references": [],
+		"startTime": "2017-01-26T16:46:31.639875Z",
+		"duration": "100000ns",
+		"tags": [],
+		"process": {
+			"serviceName": "example-service-1",
+			"tags": []
+		},
+		"logs": [
+			{
+				"timestamp": "2017-01-26T16:46:31.639875Z",
+				"fields": []
+			},
+			{
+				"timestamp": "2017-01-26T16:46:31.639875Z",
+				"fields": []
+			}
+		]
+	}`), &span))
+	assert.NoError(writer.WriteSpan(ctx, &span))
+	assert.NoError(writer.WriteSpan(ctx, &span))
+
+	assert.Equal(writesPerTable[spansTable], 2)
+	assert.Equal(writesPerTable[servicesTable], 1)
+	assert.Equal(writesPerTable[operationsTable], 1)
+}


### PR DESCRIPTION
As it is expensive to write the same service and operation items on each span, maintain an in-memory cache when they were written last and only re-write them at a fixed interval to ensure they don't expire before the span TTL.