### PR TITLE
fix: implement GSI sharding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,8 +45,7 @@ test: start-dynamodb ## Run jaeger plugin tests
 
 test-jaeger-grpc-integration: start-dynamodb ## Run jaeger integration tests for grpc plugins
 	docker compose build --build-arg GOARCH=$(GOARCH) test-jaeger-grpc-integration
-	docker compose run --rm test-jaeger-grpc-integration sh -c '$$PLUGIN_BINARY_PATH --config $$PLUGIN_CONFIG_PATH --create-tables=1 --only-create-tables=true'
-	docker compose run --rm test-jaeger-grpc-integration go test -run 'TestGRPCStorage/FindTraces' -tags=grpc_storage_integration -v -race ./plugin/storage/integration/...
+	docker compose run --rm test-jaeger-grpc-integration go test -run 'TestGRPCStorage/(GetServices|GetOperations|GetTrace|FindTraces|GetDependencies)' -tags=grpc_storage_integration -v -race ./plugin/storage/integration/...
 
 lint: ## Lint the code
 	docker run --rm -v $(PWD):/app -w /app golangci/golangci-lint:v1.42.1 golangci-lint run -v

--- a/README.md
+++ b/README.md
@@ -87,13 +87,13 @@ resource "aws_dynamodb_table" "jaeger_spans" {
   }
 
   attribute {
-    name = "ServiceName"
-    type = "S"
+    name = "SpanBucket"
+    type = "N"
   }
 
   attribute {
-    name = "StartTime"
-    type = "N"
+    name = "ServiceNameAndStartTime"
+    type = "S"
   }
 
   ttl {
@@ -113,9 +113,9 @@ resource "aws_dynamodb_table" "jaeger_spans" {
   }
 
   global_secondary_index {
-    name               = "ServiceNameIndex"
-    hash_key           = "ServiceName"
-    range_key          = "StartTime"
+    name               = "SpanSearchIndex"
+    hash_key           = "SpanBucket"
+    range_key          = "ServiceNameAndStartTime"
     projection_type    = "INCLUDE"
     non_key_attributes = ["OperationName", "Duration", "SearchableTags"]
   }

--- a/main.go
+++ b/main.go
@@ -88,7 +88,7 @@ func main() {
 
 	logger.Debug("plugin configured")
 
-	if viper.GetBool("create-tables") {
+	if viper.GetBool("create-tables") || configuration.DynamoDB.RecreateTables {
 		if err := setup.PollUntilReady(ctx, svc); err != nil {
 			log.Fatalf("unable to poll until ready, %v", err)
 		}

--- a/plugin/config/config.go
+++ b/plugin/config/config.go
@@ -1,7 +1,8 @@
 package config
 
 type DynamoDBConfiguration struct {
-	Endpoint string
+	Endpoint       string
+	RecreateTables bool
 }
 
 type Configuration struct {

--- a/setup/setup.go
+++ b/setup/setup.go
@@ -63,7 +63,7 @@ func ensureSpansTable(ctx context.Context, svc *dynamodb.Client, tableName strin
 		AttributeDefinitions: []types.AttributeDefinition{
 			{AttributeName: &traceIDKey, AttributeType: types.ScalarAttributeTypeS},
 			{AttributeName: &spanIDKey, AttributeType: types.ScalarAttributeTypeS},
-			{AttributeName: aws.String("ServiceName"), AttributeType: types.ScalarAttributeTypeS},
+			{AttributeName: aws.String("ServiceNameBucket"), AttributeType: types.ScalarAttributeTypeS},
 			{AttributeName: aws.String("StartTime"), AttributeType: types.ScalarAttributeTypeN},
 		},
 		BillingMode: types.BillingModePayPerRequest,
@@ -74,10 +74,10 @@ func ensureSpansTable(ctx context.Context, svc *dynamodb.Client, tableName strin
 		},
 		GlobalSecondaryIndexes: []types.GlobalSecondaryIndex{
 			{
-				IndexName: aws.String("ServiceNameIndex"),
+				IndexName: aws.String("SpanSearchIndex"),
 				KeySchema: []types.KeySchemaElement{
 					{
-						AttributeName: aws.String("ServiceName"),
+						AttributeName: aws.String("ServiceNameBucket"),
 						KeyType:       types.KeyTypeHash,
 					},
 					{

--- a/test-config.yml
+++ b/test-config.yml
@@ -1,2 +1,3 @@
 dynamodb:
   endpoint: http://dynamodb:8000
+  recreateTables: true


### PR DESCRIPTION
In our last production test, we have seen a large number of WriteThrottleEvents due to the GSI primary key `ServiceName` can become fairly hot, which can cause all writes to the table being throttled https://aws.amazon.com/premiumsupport/knowledge-center/dynamodb-gsi-throttling-table/

To mitigate this shard the GSI as described here https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/bp-indexes-gsi-sharding.html and perform fanout queries to all shards when searching for fitting spans.

One disadvantage is that filter results are no longer consistently ordered, but that seems to be acceptable.

This requires a two step rollout where the new global search index should be added, then the plugin updated and afterwards the previous index can be removed. (careful this means that all existing traces are no longer searchable).